### PR TITLE
feat: Allow slack token to be used as auth

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -30,6 +30,10 @@ const requireAuth = async (ctx, next) => {
                              : authCookie;
   ctx.assert(idToken, 401, 'ID token not found');
 
+  if (idToken === process.env.SLACK_TOKEN) {
+    await next();
+  }
+
   try {
     const ticket = await client.verifyIdToken({
       idToken,

--- a/src/auth.js
+++ b/src/auth.js
@@ -31,7 +31,7 @@ const requireAuth = async (ctx, next) => {
   ctx.assert(idToken, 401, 'ID token not found');
 
   if (idToken === process.env.SLACK_TOKEN) {
-    await next();
+    return await next();
   }
 
   try {


### PR DESCRIPTION
Notes
--
* In order for the slack bot to be able to interact with the api, we need a way of allowing slack bot to do auth. The approach in this PR is the simplest acceptable one I could come up with. 

@SharpNotions/ten-hour-project 