### PR TITLE
feat: Endpoint for clearing / soft-deleting user rankings

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "node-fetch": "^2.1.1",
     "objection": "^1.0.1",
     "objection-graphql": "^0.3.1",
+    "objection-softdelete": "^2.0.0",
     "pg": "^7.4.1",
     "ramda": "^0.25.0"
   },

--- a/src/app.js
+++ b/src/app.js
@@ -13,7 +13,7 @@ const {
   getItems, addItem
 } = require('./controllers/items');
 const {
-  getUserRankings, setUserRanking, getTopRankings, createUsers
+  getUserRankings, setUserRanking, getTopRankings, createUsers, clearUserRankings
 } = require('./controllers/rankings');
 const { graphql, graphiql } = require('./controllers/graphql');
 
@@ -43,6 +43,7 @@ router
   .get('*/graphiql', graphiql)
   .get('*/user_ranking', getUserRankings)
   .post('*/user_ranking', setUserRanking)
+  .del('*/user_rankings', clearUserRankings)
   .get('*/top_rankings', getTopRankings)
   .get('*/buildusers', createUsers)
 

--- a/src/controllers/rankings.js
+++ b/src/controllers/rankings.js
@@ -167,9 +167,14 @@ async function createUsers(ctx, next) {
   }, R.toPairs(userRankings))
 }
 
+async function clearUserRankings(ctx, next) {
+  const userRankings = await ctx.app.models.UserRanking.query().delete();
+  ctx.body = userRankings;
+}
 
 exports.getUserRankings = getUserRankings
 exports.setUserRanking = setUserRanking
 exports.getAllUserRankings = getAllUserRankings
 exports.getTopRankings = getTopRankings
 exports.createUsers = createUsers
+exports.clearUserRankings = clearUserRankings

--- a/src/db/db-middleware.js
+++ b/src/db/db-middleware.js
@@ -1,9 +1,13 @@
 const db = require('./connection')
 const objection = require('objection')
+const objectionSoftDelete = require('objection-softdelete')
 const models = require('../models')
 
 module.exports = (app) => {
   objection.Model.knex(db);
+  objectionSoftDelete.register(objection, {
+    deleteAttr: 'deleted_at'
+  });
   app.models = models;
 
   return (ctx, next) => next();

--- a/src/db/migrations/20180610130123_add-user-rankings-soft-delete.js
+++ b/src/db/migrations/20180610130123_add-user-rankings-soft-delete.js
@@ -1,0 +1,12 @@
+exports.up = async (knex) => {
+  await knex.schema.alterTable('user_rankings', table => {
+    table.timestamp('deleted_at')
+  })
+}
+
+exports.down = async (knex) => {
+  await knex.schema.alterTable('user_rankings', table => {
+    table.dropColumn('deleted_at')
+  })
+}
+

--- a/src/models/UserRanking.js
+++ b/src/models/UserRanking.js
@@ -6,6 +6,10 @@ class UserRanking extends Model {
     return 'user_rankings'
   }
 
+  static get softDelete() {
+    return true
+  }
+
   static get jsonSchema() {
     return {
       type: 'object',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,6 +3102,10 @@ objection-graphql@^0.3.1:
   dependencies:
     lodash "^4.17.4"
 
+objection-softdelete@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/objection-softdelete/-/objection-softdelete-2.0.0.tgz#08a9041aa2fd4982f30a32968bfe454543860a3f"
+
 objection@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/objection/-/objection-1.0.1.tgz#767d4f4b3b493fc97a4de2b37f144e5c40968f00"


### PR DESCRIPTION
https://trello.com/c/ZRDIg80l/79-endpoint-to-clear-user-rankings

It seems like it was decided at some point to abandon `deleted_at` on `items` and `users` table, but 
here I think it makes sense. 

@SharpNotions/ten-hour-project 