### PR TITLE
Update setUserRanking handler to accept prev_item_id

### DIFF
--- a/src/controllers/rankings.js
+++ b/src/controllers/rankings.js
@@ -57,16 +57,19 @@ async function setUserRanking(ctx, next) {
   const UserRanking = ctx.app.models.UserRanking;
   const graph = ctx.request.body;
   await UserRanking.query()
-    .where({ id: graph.item_id })
+    .where({
+      user_id: ctx.state.user.id,
+      item_id: graph.item_id
+    })
     .first()
     .then(existingRanking => {
       if (!existingRanking) {
         // HACK: Attach the user ID to the graph since UserRanking.insertAfter needs it.
         graph.user_id = ctx.state.user.id;
-        return UserRanking.insertAfter(graph.prev_ranking_id, graph)
+        return UserRanking.insertAfter(graph.prev_item_id, graph)
       } else {
         return existingRanking.moveAfter(
-          graph.prev_ranking_id
+          graph.prev_item_id
         );
       }
     })


### PR DESCRIPTION
Per discussion with @atomdmac, this is an easier contract for the frontend to accommodate. 

Should now be called with contract 
`POST /user_ranking - payload: { item_id, prev_item_id}`
instead of 
`POST /user_ranking - payload: { item_id, prev_ranking_id}`

@SharpNotions/ten-hour-project 