### PR TITLE
Add all Lists functionality, YUGE commit

### DIFF
--- a/src/controllers/helpers/establishList.js
+++ b/src/controllers/helpers/establishList.js
@@ -1,0 +1,16 @@
+module.exports = (handler) => async (ctx, next) => {
+  const List = ctx.app.models.List
+  const name_id = ctx.request.query.list || null
+
+  let dbList = (await List.query()
+    .where('name_id', name_id))[0]
+
+  if (!dbList) {
+    dbList = await List.query()
+      .insert({
+        name_id
+      })
+  }
+
+  return handler(dbList)(ctx, next)
+}

--- a/src/controllers/rankings.js
+++ b/src/controllers/rankings.js
@@ -5,12 +5,14 @@ const { raw }     = require('objection')
 const {
   electWithSingleTransVote, electWithFibonacci
 } = require('../election')
+const establishList = require('./helpers/establishList')
 
 const { pathOr }  = R
 
 const rankingFieldsFragment = `
   fragment RankingFields on UserRankings {
     ranking_id: id
+    list_id
     item {
       id
       item_name
@@ -21,11 +23,19 @@ const rankingFieldsFragment = `
   }
 `
 
-const rankingsForUserToDepth = (depth) => {
+const generateRankingsRecursive = (n) => {
+  if (!n || n === 1) {
+    return 'nextRanking { ...RankingFields }'
+  }
+  return `nextRanking { ...RankingFields ${generateRankingsRecursive(n - 1)}}`
+}
+
+const rankingsForUserToDepth = (list_id, depth) => {
   const recursiveRankings = generateRankingsRecursive(depth)
+  const listIdSelector = !!list_id ? `list_id: ${list_id}` : 'list_idIsNull: true'
   return `
     query UserRankings($user_id: Int) {
-      userRankings(prev_ranking_idIsNull: true, user_id: $user_id) {
+      userRankings(prev_ranking_idIsNull: true, user_id: $user_id, ${listIdSelector}) {
         ...RankingFields
         ${recursiveRankings}
       }
@@ -35,11 +45,12 @@ const rankingsForUserToDepth = (depth) => {
   `
 }
 
-const allRankingsToDepth = (depth) => {
+const allRankingsInListToDepth = (list_id, depth) => {
   const recursiveRankings = generateRankingsRecursive(depth)
+  const listIdSelector = !!list_id ? `list_id: ${list_id}` : 'list_idIsNull: true'
   return `
     query UserRankings {
-      userRankings(prev_ranking_idIsNull: true) {
+      userRankings(prev_ranking_idIsNull: true, ${listIdSelector}) {
         user_id: id
         ...RankingFields
         ${recursiveRankings}
@@ -54,25 +65,13 @@ const depthFromCtx = pathOr(10, ['request', 'query', 'depth'])
 
 const numFromCtx = pathOr(10, ['request', 'query', 'num'])
 
-async function deleteUserRanking(ctx, next) {
+const setUserRanking = establishList(list => async (ctx, next) => {
   const UserRanking = ctx.app.models.UserRanking;
-  const itemToDelete = await UserRanking.query()
-    .where({
-      user_id: ctx.state.user.id,
-      item_id: ctx.request.body.item_id
-    })
-    .first();
-  if (!itemToDelete) {
-    ctx.status = 404;
-  } else {
-    await itemToDelete.deleteFromList();
-    ctx.status = 200;
+  const graph = {
+    ...ctx.request.body,
+    user_id: ctx.state.user.id,
+    list_id: list.id
   }
-}
-
-async function setUserRanking(ctx, next) {
-  const UserRanking = ctx.app.models.UserRanking;
-  const graph = ctx.request.body;
   await UserRanking.query()
     .where({
       user_id: ctx.state.user.id,
@@ -81,8 +80,6 @@ async function setUserRanking(ctx, next) {
     .first()
     .then(existingRanking => {
       if (!existingRanking) {
-        // HACK: Attach the user ID to the graph since UserRanking.insertAfter needs it.
-        graph.user_id = ctx.state.user.id;
         return UserRanking.insertAfter(graph.prev_item_id, graph)
       } else {
         return existingRanking.moveAfter(
@@ -93,39 +90,78 @@ async function setUserRanking(ctx, next) {
     .then(body => ctx.body = body)
 
   await next()
+})
+
+const flattenRankings = (currentItem) => {
+  if (!currentItem.nextRanking) {
+    return [currentItem.item]
+  } else {
+    return [currentItem.item, ...flattenRankings(currentItem.nextRanking)]
+  }
 }
 
-async function getUserRankings(ctx, next) {
-  const depth = depthFromCtx(ctx)
+const allUserRankingsForList = list => async depth => {
   const { data } = await graphql(
     schema,
-    rankingsForUserToDepth(depth),
-    null,
-    null,
-    {user_id: ctx.state.user.id}
+    allRankingsInListToDepth(list.id, depth),
+    null
   )
+
+  const flattenedRankings = R.map(
+    head => flattenRankings(head, []),
+    data.userRankings 
+  )
+
+  return flattenedRankings
+}
+
+const getAllUserRankings = establishList(list => async (ctx, next) => {
+  const depth = depthFromCtx(ctx)
+
+  ctx.body = await allUserRankingsForList(list)(depth)
+
+  await next()
+})
+
+const getUserRankings = establishList(list => async (ctx, next) => {
+  const depth = depthFromCtx(ctx)
+
+  const { data } = await graphql(
+    schema,
+    rankingsForUserToDepth(list.id, depth),
+    null,
+    null,
+    { user_id: ctx.state.user.id }
+  )
+
   const flattenedUserRankings = data.userRankings && data.userRankings.length
     ? flattenRankings(data.userRankings[0], [])
     : [];
   ctx.body = flattenedUserRankings
 
   await next()
-}
+})
 
-async function getAllUserRankings(depth) {
-  const { data } = await graphql(
-    schema,
-    allRankingsToDepth(depth), null, null)
+const deleteUserRanking = establishList(list => async (ctx, next) => {
+  const UserRanking = ctx.app.models.UserRanking;
 
-  const flattenedRankings = R.map(
-    head => flattenRankings(head, []),
-    data.userRankings
-  )
+  const itemToDelete = await UserRanking.query()
+    .where({
+      user_id: ctx.state.user.id,
+      item_id: ctx.request.body.item_id,
+      list_id: list.id
+    })
+    .first();
 
-  return flattenedRankings
-}
+  if (!itemToDelete) {
+    ctx.status = 404;
+  } else {
+    await itemToDelete.deleteFromList();
+    ctx.status = 200;
+  }
+})
 
-async function computeTopRankings(numTopRankings, allRankings) {
+const computeTopRankings = (numTopRankings, allRankings) => {
   const singleTransVoteRankings = electWithSingleTransVote(
     numTopRankings,
     allRankings
@@ -141,106 +177,54 @@ async function computeTopRankings(numTopRankings, allRankings) {
   }
 }
 
-async function getTopRankings(ctx, next) {
+const getTopRankings = establishList(list => async (ctx, next) => {
   const num = numFromCtx(ctx)
   const depth = depthFromCtx(ctx)
-  const allRankings = await getAllUserRankings(depth)
+  const allRankings = await allUserRankingsForList(list)(depth)
 
   ctx.body = await computeTopRankings(num, allRankings)
 
   await next()
-}
+})
 
-function generateRankingsRecursive(n) {
-  if (n === 1) {
-    return 'nextRanking { ...RankingFields }'
-  }
-  return `nextRanking { ...RankingFields ${generateRankingsRecursive(n - 1)}}`
-}
-
-function flattenRankings(currentItem) {
-  if (!currentItem.nextRanking) {
-    return [currentItem.item]
-  } else {
-    return [currentItem.item, ...flattenRankings(currentItem.nextRanking)]
-  }
-}
-
-async function createUsers(ctx, next) {
-  const userRankings = {
-    // 1: [5,1,4,5,2],
-    // 2: [2,3,1,5,4],
-    // 3: [3,2,1,4,5],
-    // 4: [2,1,3,4,5],
-    // 5: [5,2,1,4,3],
-    // 6: [1,4,5,3,2]
-    1: [5,1,4,10,2,8],
-    2: [2,3,1,5,4,7,8,6,10,9],
-    3: [3,2,1,4,5],
-    4: [2],
-    5: [5,2,1,4,3],
-    6: [1,4,8,4,9,10,6,7,5,3,2],
-    7: [5,3,2,1,6,7,8,4,9,10]
-  }
-
-  const asyncForEach = async (f, data) => {
-    if (data.length === 0) return;
-    await f(R.head(data))
-    await asyncForEach(f, R.tail(data))
-  }
-
-  await asyncForEach(async ([user_id, itemIds]) => {
-    user_id = +user_id
-    let prevUserRankingId = null
-    await asyncForEach(async item_id => {
-      item_id = +item_id
-
-      const newRanking = await ctx.app.models.UserRanking.insertAfter(prevUserRankingId, {
-        item_id,
-        user_id
-      })
-      console.log('inserted', user_id, item_id)
-      prevUserRankingId = newRanking.id
-    }, itemIds)
-  }, R.toPairs(userRankings))
-
-  await next()
-}
-
-async function clearUserRankings(ctx, next) {
-  await saveSnapshot(ctx);
-
-  const deletedUserRankings = await ctx.app.models.UserRanking.query().delete();
-  ctx.body = deletedUserRankings;
-
-  await next()
-}
-
-async function saveSnapshot(ctx) {
+const saveSnapshot = establishList(list => async (ctx, next) => {
   const {
     UserRanking, RankingsSnapshot
   } = ctx.app.models
 
   const num = numFromCtx(ctx)
   const depth = depthFromCtx(ctx)
-  const allUserRankingsLists = await getAllUserRankings(depth)
+  const allUserRankingsLists = await allUserRankingsForList(list)(depth)
 
   const user_rankings = await UserRanking.query()
+    .where({list_id: list.id})
   const top_rankings = await computeTopRankings(num, allUserRankingsLists)
 
   await RankingsSnapshot.query()
     .insert({
       snapshot: {
+        list,
         user_rankings,
         top_rankings
       }
     })
-}
+})
+
+const clearUserRankings = establishList(list => async (ctx, next) => {
+  await saveSnapshot(ctx);
+
+  const deletedUserRankings = await ctx.app.models.UserRanking.query()
+    .delete()
+    .where({list_id: list.id})
+
+  ctx.body = deletedUserRankings;
+
+  await next()
+})
 
 exports.getUserRankings = getUserRankings
 exports.setUserRanking = setUserRanking
 exports.deleteUserRanking = deleteUserRanking
 exports.getAllUserRankings = getAllUserRankings
 exports.getTopRankings = getTopRankings
-exports.createUsers = createUsers
 exports.clearUserRankings = clearUserRankings

--- a/src/db/migrations/20180915171036_create-lists-table.js
+++ b/src/db/migrations/20180915171036_create-lists-table.js
@@ -1,0 +1,10 @@
+exports.up = knex =>
+  knex.schema.createTable('lists', table => {
+    table.increments('id')
+    table.string('name_id')
+      .unique()
+    table.timestamps(true, true)
+  })
+
+exports.down = knex =>
+  knex.schema.dropTable('lists')

--- a/src/db/migrations/20180916211233_add-lists-foreign-keys.js
+++ b/src/db/migrations/20180916211233_add-lists-foreign-keys.js
@@ -1,0 +1,38 @@
+exports.up = async knex => {
+  await knex.schema.raw(`
+    INSERT INTO lists (id, name_id, created_at, updated_at)
+    SELECT nextval('lists_id_seq'), NULL, now(), now()
+    WHERE
+    NOT EXISTS (
+        SELECT id FROM lists WHERE name_id = NULL
+    );
+  `)
+
+  const {id: nullListId} = (await knex.select('id').from('lists').where({name_id: null}))[0]
+
+  await knex.schema.table('items', table => {
+    table.integer('list_id')
+      .notNullable()
+      .defaultTo(nullListId)
+      .references('id')
+      .inTable('lists')
+  })
+
+  await knex.schema.table('user_rankings', table => {
+    table.integer('list_id')
+      .notNullable()
+      .defaultTo(nullListId)
+      .references('id')
+      .inTable('lists')
+  })
+}
+
+exports.down = async knex => {
+  await knex.schema.table('items', table => {
+    table.dropColumn('list_id')
+  })
+
+  await knex.schema.table('user_rankings', table => {
+    table.dropColumn('list_id')
+  })
+}

--- a/src/models/Item.js
+++ b/src/models/Item.js
@@ -18,13 +18,16 @@ class Item extends Model {
           properties: {
             description: { type: 'string' }
           }
-        }
+        },
+        list_id: {type: 'integer'}
       }
     }
   }
 
   static get relationMappings() {
     const UserRanking = require('./UserRanking');
+    const List        = require('./List');
+
     return {
       userRankings: {
         relation: Model.HasManyRelation,
@@ -32,6 +35,14 @@ class Item extends Model {
         join: {
           from: 'items.id',
           to: 'user_rankings.item_id'
+        }
+      },
+      list: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: List,
+        join: {
+          from: 'items.list_id',
+          to: 'lists.id'
         }
       }
     }

--- a/src/models/List.js
+++ b/src/models/List.js
@@ -1,0 +1,49 @@
+const { Model } = require('objection')
+
+class List extends Model {
+  // Table name is the only required property.
+  static get tableName() {
+    return 'lists';
+  }
+
+  static get jsonSchema() {
+    return {
+      type: 'object',
+      required: ['name_id'],
+      properties: {
+        id: {
+          type: 'integer'
+        },
+        name_id: {
+          type: ['string', null]
+        }
+      }
+    }
+  }
+
+  static get relationMappings() {
+    const UserRanking = require('./UserRanking');
+    const Item        = require('./Item');
+
+    return {
+      userRankings: {
+        relation: Model.HasManyRelation,
+        modelClass: UserRanking,
+        join: {
+          from: 'lists.id',
+          to: 'user_rankings.list_id'
+        }
+      },
+      items: {
+        relation: Model.HasManyRelation,
+        modelClass: Item,
+        join: {
+          from: 'lists.id',
+          to: 'items.list_id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = List;

--- a/src/models/UserRanking.js
+++ b/src/models/UserRanking.js
@@ -19,6 +19,7 @@ class UserRanking extends Model {
         item_id: {type: 'integer'},
         user_id: {type: 'integer'},
         prev_ranking_id: {type: ['integer', null]},
+        list_id: {type: 'integer'},
       }
     };
   }
@@ -26,6 +27,7 @@ class UserRanking extends Model {
   static get relationMappings() {
     const Item = require('./Item');
     const User = require('./User');
+    const List = require('./List');
 
     return {
       item: {
@@ -58,6 +60,14 @@ class UserRanking extends Model {
         join: {
           from: 'user_rankings.id',
           to: 'user_rankings.prev_ranking_id'
+        }
+      },
+      list: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: List,
+        join: {
+          from: 'user_rankings.list_id',
+          to: 'lists.id'
         }
       }
     }

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   User            : require('./User'),
   Item            : require('./Item'),
+  List            : require('./List'),
   RankingsSnapshot: require('./RankingsSnapshot'),
   UserRanking     : require('./UserRanking')
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,47 @@
+const Router              = require('koa-router');
+const {graphql, graphiql} = require('./controllers/graphql');
+const auth                = require('./auth');
+const {
+  getUnrankedItems, addItem
+} = require('./controllers/items');
+const {
+  getUserRankings, setUserRanking, getTopRankings, clearUserRankings,
+  deleteUserRanking,
+  getAllUserRankings
+} = require('./controllers/rankings');
+
+const router = new Router()
+
+router
+  .get('/', async (ctx, next) => {
+    ctx.body = 'Hello World'
+    await next()
+  })
+  .get('/handle_google_callback', async (ctx, next) => {
+    ctx.assert(ctx.session.grant.response.raw, 401, 'Auth Failed')
+    ctx.cookies.set('id_token', ctx.session.grant.response.raw.id_token)
+    ctx.redirect(ctx.cookies.get('after_login'))
+    await next()
+  })
+  .get('*/ping', async (ctx, next) => {
+    ctx.body = `pong ${new Date().toString()}`;
+    await next()
+  })
+  // .use(auth)
+  .get('*/protected', async (ctx, next) => {
+    ctx.body = `Protected`;
+    await next()
+  })
+  .get('*/unranked_items', getUnrankedItems)
+  .post('*/item', addItem)
+  .get('*/graphql', graphql)
+  .post('*/graphql', graphql)
+  .get('*/graphiql', graphiql)
+  .get('*/user_ranking', getUserRankings)
+  .post('*/user_ranking', setUserRanking)
+  .del('*/user_ranking', deleteUserRanking)
+  .get('*/all_user_rankings', getAllUserRankings)
+  .del('*/all_user_rankings', clearUserRankings)
+  .get('*/top_rankings', getTopRankings)
+
+module.exports = router


### PR DESCRIPTION
I have a minimum-acceptable level of confidence in this PR.

- Adds `lists` table to DB, `list_id` column to `user_rankings` and `items`.
- For now, `items` are locked down to a specific list. I recognize that we should have a many-to-many join table between `items` and `lists`, but we can refactor when we decide we really want it.
- Wrap all rankings and items endpoints in a `list` query-param accepting decorator.
- Move routes to `routes.js`

@SharpNotions/ten-hour-project 